### PR TITLE
refactor: unify fname parsing and add support for reading filenames a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to this project are documented in this file.
 ### [Under development]
 
 #### Added
-  - a central read dispatcher (#33)
-  - refactor reader: on empty requested_fields, retain all available fields (#40)
+  - refactor IO:
+      - a central read dispatcher (#33)
+      - on empty requested_fields, retain all available fields (#40)
+      - accept strings (#42)
 
 #### Fixes
   - fix: turn geometry and diagnostics into sub-packages (#34)

--- a/src/sgs_tools/io/read.py
+++ b/src/sgs_tools/io/read.py
@@ -9,7 +9,7 @@ from sgs_tools.io.um import data_ingest_UM_on_single_grid
 
 
 def read(
-    input_files: Path, input_format: str, requested_fields: list[str], **kwargs
+    input_files: Path | str, input_format: str, requested_fields: list[str], **kwargs
 ) -> xr.Dataset:
     """
     Read simulation data from input files and return an xarray Dataset.

--- a/src/sgs_tools/io/read_util.py
+++ b/src/sgs_tools/io/read_util.py
@@ -1,6 +1,20 @@
+from pathlib import Path
 from typing import Dict, Iterable
 
 import xarray as xr
+
+
+def parse_fname_pattern(fname_pattern: str | Path) -> list[Path]:
+    """
+    parse any glob wildcards from ``fname_pattern``
+    return a list of concrete Paths
+    """
+    print(f"Parsing {fname_pattern}")
+    fpattern = Path(fname_pattern)
+    # return list because of incomplete typehints of xr.open_mfdataset
+    return list(
+        Path(fpattern.root).glob(str(Path(*fpattern.parts[fpattern.is_absolute() :])))
+    )
 
 
 def standardize_varnames(

--- a/src/sgs_tools/io/sgs.py
+++ b/src/sgs_tools/io/sgs.py
@@ -3,13 +3,17 @@ from typing import Any, Dict
 
 import xarray as xr
 
-from sgs_tools.io.read_util import restrict_ds, standardize_varnames
+from sgs_tools.io.read_util import (
+    parse_fname_pattern,
+    restrict_ds,
+    standardize_varnames,
+)
 
 degenerate_naming_convention: Dict[str, str] = {}
 
 
 def data_ingest_SGS(
-    fname_pattern,
+    fname_pattern: Path | str,
     requested_fields: list[str] = ["u", "v", "w", "theta"],
     chunks: Any = "auto",
 ):
@@ -20,12 +24,9 @@ def data_ingest_SGS(
     :param requested_fields: list of fields to retain in ds, if falsy will retain all.
     :param chunks: chunking for data
     """
-    fname = list(
-        Path(fname_pattern.root).glob(
-            str(Path(*fname_pattern.parts[fname_pattern.is_absolute() :]))
-        )
-    )
-
+    # parse filename (glob, ~, etc.)
+    fname = parse_fname_pattern(fname_pattern)
+    # open file(s)
     ds = xr.open_mfdataset(fname, chunks=chunks, parallel=True, engine="h5netcdf")
     # rename to sgs_tools naming convention
     ds = standardize_varnames(ds, degenerate_naming_convention)


### PR DESCRIPTION
## Description

unify fname parsing when reading filenama pattern  and add support for reading filenames as strings.

## Related Issue(s)


## Type of Change

Please delete options that are not relevant.

- New feature
- Refactor

## Checklist

- [-] Added or updated unit tests, if applicable.
- [x] All tests pass locally (`tox` or `make clean` runs clean).
- [x] The CI pipeline passes (e.g., GitHub Actions).
- [-] Udated documentation, where applicable.
- [-] Updated CHANGELOG, TASKLIST if applicable.
- [-] Updated package dependencies, poetry.lock, pre_commit, etc., if applicable.

# Additional Notes

